### PR TITLE
Add basic hello world template

### DIFF
--- a/lib/utils/common-prompts.ts
+++ b/lib/utils/common-prompts.ts
@@ -31,4 +31,12 @@ export namespace NpmClientPrompt {
     message: 'Choose an NPM client:',
     choices: ['npm', 'yarn'],
   };
+
+  export function getInstallCommand(data: Data) {
+    return data.npmClient === 'npm' ? 'npm install' : 'yarn install';
+  }
+
+  export function getStartCommand(data: Data) {
+    return data.npmClient === 'npm' ? 'npm start' : 'yarn start';
+  }
 }

--- a/lib/utils/common-prompts.ts
+++ b/lib/utils/common-prompts.ts
@@ -1,0 +1,34 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+
+import { Questions } from 'zombi';
+
+/**
+ * Types and questions related to Magic public API key selection.
+ */
+export namespace PublicApiKeyPrompt {
+  export type Data = {
+    publicApiKey: 'npm' | 'yarn';
+  };
+
+  export const questions: Questions<Data> = {
+    type: 'input',
+    name: 'publicApiKey',
+    message: 'Enter your Magic public API key:',
+  };
+}
+
+/**
+ * Types and questions related to NPM client selection for JS-based projects.
+ */
+export namespace NpmClientPrompt {
+  export type Data = {
+    npmClient: 'npm' | 'yarn';
+  };
+
+  export const questions: Questions<Data> = {
+    type: 'select',
+    name: 'npmClient',
+    message: 'Choose an NPM client:',
+    choices: ['npm', 'yarn'],
+  };
+}

--- a/lib/utils/merge-prompts.ts
+++ b/lib/utils/merge-prompts.ts
@@ -1,0 +1,32 @@
+import { Questions } from 'zombi';
+
+/**
+ * Merge multiple `Zombi` prompt sources into one array.
+ */
+
+/* eslint-disable prettier/prettier */
+export function mergePrompts<A>(...questions: [Questions<A>]): Questions<A>;
+export function mergePrompts<A, B>(...questions: [Questions<A>, Questions<B>]): Questions<A & B>;
+export function mergePrompts<A, B, C>(...questions: [Questions<A>, Questions<B>, Questions<C>]): Questions<A & B & C>;
+export function mergePrompts<A, B, C, D>(...questions: [Questions<A>, Questions<B>, Questions<C>, Questions<D>]): Questions<A & B & C & D>;
+export function mergePrompts<A, B, C, D, E>(...questions: [Questions<A>, Questions<B>, Questions<C>, Questions<D>, Questions<E>]): Questions<A & B & C & D & E>;
+export function mergePrompts<A, B, C, D, E, F>(...questions: [Questions<A>, Questions<B>, Questions<C>, Questions<D>, Questions<E>, Questions<F>]): Questions<A & B & C & D & E & F>;
+export function mergePrompts<A, B, C, D, E, F, G>(...questions: [Questions<A>, Questions<B>, Questions<C>, Questions<D>, Questions<E>, Questions<F>, Questions<G>]): Questions<A & B & C & D & E & F & G>;
+export function mergePrompts<A, B, C, D, E, F, G, H>(...questions: [Questions<A>, Questions<B>, Questions<C>, Questions<D>, Questions<E>, Questions<F>, Questions<G>, Questions<H>]): Questions<A & B & C & D & E & F & G & H>;
+export function mergePrompts<A, B, C, D, E, F, G, H, I>(...questions: [Questions<A>, Questions<B>, Questions<C>, Questions<D>, Questions<E>, Questions<F>, Questions<G>, Questions<H>, Questions<I>]): Questions<A & B & C & D & E & F & G & H & I>;
+export function mergePrompts<A, B, C, D, E, F, G, H, I, J>(...questions: [Questions<A>, Questions<B>, Questions<C>, Questions<D>, Questions<E>, Questions<F>, Questions<G>, Questions<H>, Questions<I>, Questions<J>]): Questions<A & B & C & D & E & F & G & H & I & J>;
+/* eslint-enable prettier/prettier */
+
+export function mergePrompts(...questions: Questions<any>[]): Questions<any> {
+  const result: Questions<any> = [];
+
+  questions.forEach((q) => {
+    if (Array.isArray(q)) {
+      result.push(...q);
+    } else {
+      result.push(q);
+    }
+  });
+
+  return result;
+}

--- a/lib/utils/scaffold-helpers.ts
+++ b/lib/utils/scaffold-helpers.ts
@@ -6,19 +6,19 @@
 import { getAbsoluteTemplatePath, resolveToDist } from './path-helpers';
 import type { CreateMagicAppData } from '../create-app';
 
-type ScaffoldRender = (props: {
+type ScaffoldRender<T = Record<string, any>> = (props: {
   name: string;
   templateRoot: string;
-  data: CreateMagicAppData & Record<string, any>;
+  data: T & CreateMagicAppData;
 }) => JSX.Element;
 
-type ScaffoldMetadata = {
+type ScaffoldMetadata<T = Record<string, any>> = {
   shortDescription: string;
-  installDependenciesCommand?: string;
-  startCommand?: string;
+  installDependenciesCommand?: string | ((data: T & CreateMagicAppData) => string);
+  startCommand?: string | ((data: T & CreateMagicAppData) => string);
 };
 
-export type ScaffoldDefinition = ScaffoldRender & ScaffoldMetadata;
+export type ScaffoldDefinition<T = Record<string, any>> = ScaffoldRender<T> & ScaffoldMetadata<T>;
 
 /**
  * Creates the definition object for a scaffolding template.
@@ -26,7 +26,10 @@ export type ScaffoldDefinition = ScaffoldRender & ScaffoldMetadata;
  * The return value of this function should be the default export
  * of a `[root]/scaffolds/[scaffoldName]/scaffold.{ts,tsx}` file.
  */
-export function createScaffold(scaffoldRender: ScaffoldRender, metadata: ScaffoldMetadata): ScaffoldDefinition {
+export function createScaffold<T>(
+  scaffoldRender: ScaffoldRender<T>,
+  metadata: ScaffoldMetadata<T>,
+): ScaffoldDefinition<T> {
   return Object.assign(scaffoldRender, { ...metadata });
 }
 

--- a/scaffolds/hello-world/scaffold.tsx
+++ b/scaffolds/hello-world/scaffold.tsx
@@ -14,8 +14,8 @@ export default createScaffold<HelloWorldData>(
   ),
 
   {
-    shortDescription: 'Just testing...',
-    installDependenciesCommand: (data) => (data.npmClient === 'npm' ? 'npm install' : 'yarn install'),
-    startCommand: (data) => (data.npmClient === 'npm' ? 'npm start' : 'yarn start'),
+    shortDescription: 'Hello world',
+    installDependenciesCommand: NpmClientPrompt.getInstallCommand,
+    startCommand: NpmClientPrompt.getStartCommand,
   },
 );

--- a/scaffolds/hello-world/scaffold.tsx
+++ b/scaffolds/hello-world/scaffold.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import { Template, Zombi } from 'zombi';
 import { createScaffold } from 'lib/utils/scaffold-helpers';
+import { NpmClientPrompt, PublicApiKeyPrompt } from 'lib/utils/common-prompts';
+import { mergePrompts } from 'lib/utils/merge-prompts';
 
-export default createScaffold(
+type HelloWorldData = NpmClientPrompt.Data & PublicApiKeyPrompt.Data;
+
+export default createScaffold<HelloWorldData>(
   (props) => (
-    <Zombi {...props}>
+    <Zombi {...props} prompts={mergePrompts(PublicApiKeyPrompt.questions, NpmClientPrompt.questions)}>
       <Template source="./" />
     </Zombi>
   ),
 
   {
     shortDescription: 'Just testing...',
-    installDependenciesCommand: 'echo install deps',
-    startCommand: 'echo start app',
+    installDependenciesCommand: (data) => (data.npmClient === 'npm' ? 'npm install' : 'yarn install'),
+    startCommand: (data) => (data.npmClient === 'npm' ? 'npm start' : 'yarn start'),
   },
 );

--- a/scaffolds/hello-world/template/example.txt
+++ b/scaffolds/hello-world/template/example.txt
@@ -1,1 +1,0 @@
-hello world

--- a/scaffolds/hello-world/template/index.html
+++ b/scaffolds/hello-world/template/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Magic Hello World 🌎</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" type="text/css" href="styles.css" />
+    <!-- 1️⃣ Install Magic SDK -->
+    <script src="https://cdn.jsdelivr.net/npm/magic-sdk@latest/dist/magic.js"></script>
+    <script>
+      /* 2️⃣ Initialize Magic Instance */
+      let magic = new Magic("<%= publicApiKey %>");
+
+      /* 3️⃣ Implement Render Function */
+      const render = async () => {
+        let html = '';
+
+        if (window.location.pathname === "/callback") {
+          try {
+            /* Complete the "authentication callback" */
+            await magic.auth.loginWithCredential();
+
+            /* Get user metadata including email */
+            const userMetadata = await magic.user.getMetadata();
+
+            html = `
+              <h1>Current user: ${userMetadata.email}</h1>
+              <button onclick="handleLogout()">Logout</button>
+            `;
+          } catch {
+            window.location.href = window.location.origin;
+          }
+        } else {
+          const isLoggedIn = await magic.user.isLoggedIn();
+
+          /* Show login form if user is not logged in */
+          html = `
+            <h1>Please sign up or login</h1>
+            <form onsubmit="handleLogin(event)">
+              <input type="email" name="email" required="required" placeholder="Enter your email" />
+              <button type="submit">Send</button>
+            </form>
+          `;
+
+          if (isLoggedIn) {
+            /* Get user metadata including email */
+            const userMetadata = await magic.user.getMetadata();
+            html = `
+              <h1>Current user: ${userMetadata.email}</h1>
+              <button onclick="handleLogout()">Logout</button>
+            `;
+          }
+        }
+
+        document.getElementById("app").innerHTML = html;
+      };
+
+      /* 4️⃣ Implement Login Handler */
+      const handleLogin = async (e) => {
+        e.preventDefault();
+        const email = new FormData(e.target).get("email");
+        const redirectURI = `${window.location.origin}/callback`;
+        if (email) {
+          /* One-liner login 🤯 */
+          await magic.auth.loginWithMagicLink({ email, redirectURI });
+          render();
+        }
+      };
+
+      /* 5️⃣ Implement Logout Handler */
+      const handleLogout = async () => {
+        await magic.user.logout();
+        render();
+      };
+    </script>
+  </head>
+  <body onload="render()">
+    <div id="app">
+      Loading...
+    </div>
+  </body>
+</html>

--- a/scaffolds/hello-world/template/package.json
+++ b/scaffolds/hello-world/template/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "<%= projectName %>",
+  "version": "0.1.0",
+  "description": "A vanilla HTML + JS app with Magic passwordless authentication.",
+  "main": "index.html",
+  "scripts": {
+    "start": "http-server --proxy http://localhost:8080? -o /"
+  },
+  "dependencies": {
+    "http-server": "^0.12.3"
+  }
+}

--- a/scaffolds/hello-world/template/styles.css
+++ b/scaffolds/hello-world/template/styles.css
@@ -1,0 +1,32 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  height: 100vh;
+  display: grid;
+  font-size: 18px;
+}
+
+#app {
+  align-self: center;
+  justify-self: center;
+  background-color: #eee;
+  text-align: center;
+  width: 300px;
+  padding: 27px 18px;
+}
+
+h1 {
+  margin: 0;
+  padding-bottom: 18px;
+  font-size: 18px;
+}
+
+input {
+  margin-bottom: 9px;
+}
+
+input,
+button {
+  padding: 9px;
+  font-size: 18px;
+}

--- a/scaffolds/hello-world/template/test.ts
+++ b/scaffolds/hello-world/template/test.ts
@@ -1,1 +1,0 @@
-console.log('hello world')


### PR DESCRIPTION
Adds a working `hello-world` template [based on Magic's CodeSandbox example](https://github.com/magiclabs/example-hello-world-with-redirect).

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
