### PR TITLE
Use `localhost` as the address for Hello World server

### DIFF
--- a/scaffolds/hello-world/template/package.json
+++ b/scaffolds/hello-world/template/package.json
@@ -4,7 +4,7 @@
   "description": "A vanilla HTML + JS app with Magic passwordless authentication.",
   "main": "index.html",
   "scripts": {
-    "start": "http-server --proxy http://localhost:8080? -o /"
+    "start": "http-server -a localhost --proxy http://localhost:8080? -o /"
   },
   "dependencies": {
     "http-server": "^0.12.3"


### PR DESCRIPTION
The underlying server we use for "Hello world" is [`http-server`](https://github.com/http-party/http-server#readme), which defaults to `0.0.0.0` for the address, which was breaking login with redirect. Now we explicitly set the address to `localhost` to fix the example!

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
