### PR TITLE
Change '--public-api-key' to '--publishable-api-key'

### DIFF
--- a/scaffolds/binance-smart-chain/scaffold.tsx
+++ b/scaffolds/binance-smart-chain/scaffold.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Template, Zombi } from 'zombi';
 import { createScaffold } from 'cli/utils/scaffold-helpers';
 import { mergePrompts } from 'cli/utils/merge-prompts';
-import { NpmClientPrompt, PublicApiKeyPrompt } from 'scaffolds/prompts';
+import { NpmClientPrompt, PublishableApiKeyPrompt } from 'scaffolds/prompts';
 
-type BinanceSmartChainData = NpmClientPrompt.Data & PublicApiKeyPrompt.Data;
+type BinanceSmartChainData = NpmClientPrompt.Data & PublishableApiKeyPrompt.Data;
 
 export default createScaffold<BinanceSmartChainData>(
   (props) => (
-    <Zombi {...props} prompts={mergePrompts(PublicApiKeyPrompt.questions, NpmClientPrompt.questions)}>
+    <Zombi {...props} prompts={mergePrompts(PublishableApiKeyPrompt.questions, NpmClientPrompt.questions)}>
       <Template source="./" />
     </Zombi>
   ),
@@ -20,7 +20,7 @@ export default createScaffold<BinanceSmartChainData>(
     startCommand: NpmClientPrompt.getStartCommand,
     flags: {
       ...NpmClientPrompt.flags,
-      ...PublicApiKeyPrompt.flags,
+      ...PublishableApiKeyPrompt.flags,
     },
   },
 );

--- a/scaffolds/binance-smart-chain/template/index.html
+++ b/scaffolds/binance-smart-chain/template/index.html
@@ -14,7 +14,7 @@
         chainId: 97 // Smart Chain Mainnet Chain ID
       };
       /* Configure Ethereum provider */
-      const magic = new Magic("<%= publicApiKey %>", {
+      const magic = new Magic("<%= publishableApiKey %>", {
         network: BSCOptions
       });
       const web3 = new Web3(magic.rpcProvider);

--- a/scaffolds/hello-world-react/scaffold.tsx
+++ b/scaffolds/hello-world-react/scaffold.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Template, Zombi } from 'zombi';
 import { createScaffold } from 'cli/utils/scaffold-helpers';
 import { mergePrompts } from 'cli/utils/merge-prompts';
-import { NpmClientPrompt, PublicApiKeyPrompt } from 'scaffolds/prompts';
+import { NpmClientPrompt, PublishableApiKeyPrompt } from 'scaffolds/prompts';
 
-type HelloWorldReactData = NpmClientPrompt.Data & PublicApiKeyPrompt.Data;
+type HelloWorldReactData = NpmClientPrompt.Data & PublishableApiKeyPrompt.Data;
 
 export default createScaffold<HelloWorldReactData>(
   (props) => (
-    <Zombi {...props} prompts={mergePrompts(PublicApiKeyPrompt.questions, NpmClientPrompt.questions)}>
+    <Zombi {...props} prompts={mergePrompts(PublishableApiKeyPrompt.questions, NpmClientPrompt.questions)}>
       <Template source="./" />
     </Zombi>
   ),
@@ -20,7 +20,7 @@ export default createScaffold<HelloWorldReactData>(
     startCommand: NpmClientPrompt.getStartCommand,
     flags: {
       ...NpmClientPrompt.flags,
-      ...PublicApiKeyPrompt.flags,
+      ...PublishableApiKeyPrompt.flags,
     },
   },
 );

--- a/scaffolds/hello-world-react/template/src/magic.js
+++ b/scaffolds/hello-world-react/template/src/magic.js
@@ -1,2 +1,2 @@
 import { Magic } from "magic-sdk";
-export const magic = new Magic("<%= publicApiKey %>");
+export const magic = new Magic("<%= publishableApiKey %>");

--- a/scaffolds/hello-world-social-login/scaffold.tsx
+++ b/scaffolds/hello-world-social-login/scaffold.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { Template, Zombi } from 'zombi';
 import { createScaffold } from 'cli/utils/scaffold-helpers';
 import { mergePrompts } from 'cli/utils/merge-prompts';
-import { NpmClientPrompt, PublicApiKeyPrompt, SocialLoginsPrompt } from 'scaffolds/prompts';
+import { NpmClientPrompt, PublishableApiKeyPrompt, SocialLoginsPrompt } from 'scaffolds/prompts';
 
-type HelloWorldSocialLoginData = NpmClientPrompt.Data & PublicApiKeyPrompt.Data & SocialLoginsPrompt.Data;
+type HelloWorldSocialLoginData = NpmClientPrompt.Data & PublishableApiKeyPrompt.Data & SocialLoginsPrompt.Data;
 
 export default createScaffold<HelloWorldSocialLoginData>(
   (props) => (
     <Zombi
       {...props}
-      prompts={mergePrompts(PublicApiKeyPrompt.questions, SocialLoginsPrompt.questions, NpmClientPrompt.questions)}
+      prompts={mergePrompts(PublishableApiKeyPrompt.questions, SocialLoginsPrompt.questions, NpmClientPrompt.questions)}
     >
       {(data) => {
         return (
@@ -45,7 +45,7 @@ export default createScaffold<HelloWorldSocialLoginData>(
     startCommand: NpmClientPrompt.getStartCommand,
     flags: {
       ...NpmClientPrompt.flags,
-      ...PublicApiKeyPrompt.flags,
+      ...PublishableApiKeyPrompt.flags,
       ...SocialLoginsPrompt.flags,
     },
   },

--- a/scaffolds/hello-world-social-login/template/src/magic.js
+++ b/scaffolds/hello-world-social-login/template/src/magic.js
@@ -3,6 +3,6 @@ import { OAuthExtension } from "@magic-ext/oauth";
 
 export const socialLogins = [<%- socialLogin.reduce((a, b) => a ? `${a}, "${b}"` : `"${b}"`, "") %>];
 
-export const magic = new Magic("<%= publicApiKey %>", {
+export const magic = new Magic("<%= publishableApiKey %>", {
   extensions: [new OAuthExtension()],
 });

--- a/scaffolds/hello-world/scaffold.tsx
+++ b/scaffolds/hello-world/scaffold.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Template, Zombi } from 'zombi';
 import { createScaffold } from 'cli/utils/scaffold-helpers';
 import { mergePrompts } from 'cli/utils/merge-prompts';
-import { NpmClientPrompt, PublicApiKeyPrompt } from 'scaffolds/prompts';
+import { NpmClientPrompt, PublishableApiKeyPrompt } from 'scaffolds/prompts';
 
-type HelloWorldData = NpmClientPrompt.Data & PublicApiKeyPrompt.Data;
+type HelloWorldData = NpmClientPrompt.Data & PublishableApiKeyPrompt.Data;
 
 export default createScaffold<HelloWorldData>(
   (props) => (
-    <Zombi {...props} prompts={mergePrompts(PublicApiKeyPrompt.questions, NpmClientPrompt.questions)}>
+    <Zombi {...props} prompts={mergePrompts(PublishableApiKeyPrompt.questions, NpmClientPrompt.questions)}>
       <Template source="./" />
     </Zombi>
   ),
@@ -20,7 +20,7 @@ export default createScaffold<HelloWorldData>(
     startCommand: NpmClientPrompt.getStartCommand,
     flags: {
       ...NpmClientPrompt.flags,
-      ...PublicApiKeyPrompt.flags,
+      ...PublishableApiKeyPrompt.flags,
     },
   },
 );

--- a/scaffolds/hello-world/template/index.html
+++ b/scaffolds/hello-world/template/index.html
@@ -9,7 +9,7 @@
     <script src="https://cdn.jsdelivr.net/npm/magic-sdk@latest/dist/magic.js"></script>
     <script>
       /* 2️⃣ Initialize Magic Instance */
-      let magic = new Magic("<%= publicApiKey %>");
+      let magic = new Magic("<%= publishableApiKey %>");
 
       /* 3️⃣ Implement Render Function */
       const render = async () => {

--- a/scaffolds/prompts.ts
+++ b/scaffolds/prompts.ts
@@ -4,26 +4,26 @@ import type { Questions } from 'zombi';
 import type { Flags } from 'cli/flags';
 import type { ValuesOf } from 'cli/types/utility-types';
 
-export namespace PublicApiKeyPrompt {
+export namespace PublishableApiKeyPrompt {
   export type Data = {
-    publicApiKey: 'npm' | 'yarn';
+    publishableApiKey: 'npm' | 'yarn';
   };
 
   const validate = (value: string) =>
-    value.startsWith('pk') ? true : '--public-api-key should look like `pk_live_...` or `pk_test_...`';
+    value.startsWith('pk') ? true : '--publishable-api-key should look like `pk_live_...` or `pk_test_...`';
 
   export const questions: Questions<Data> = {
     type: 'input',
-    name: 'publicApiKey',
+    name: 'publishableApiKey',
     validate,
-    message: 'Enter your Magic public API key:',
+    message: 'Enter your Magic publishable API key:',
   };
 
   export const flags: Flags<Data> = {
-    publicApiKey: {
+    publishableApiKey: {
       type: String,
       validate,
-      description: 'The Magic public API key for your app.',
+      description: 'The Magic publishable API key for your app.',
     },
   };
 }


### PR DESCRIPTION
Changes the `--public-api-key` argument to `--publishable-api-key` to maintain consistency between docs, Dashboard, and guides content.

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
