### PR TITLE
auto jwt gen for hasura template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-magic",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A tool for quickly scaffolding an app with Magic authentication baked-in!",
   "repository": "magiclabs/create-magic-app",
   "license": "MIT",

--- a/scaffolds/hasura/scaffold.tsx
+++ b/scaffolds/hasura/scaffold.tsx
@@ -12,10 +12,10 @@ type HasuraData = NpmClientPrompt.Data &
     jwtSecret: string;
   };
 
-const generateJwtSecret = () => {
+function generateJwtSecret() {
   const buffer = crypto.randomBytes(32);
   return buffer.toString('hex');
-};
+}
 
 export default createScaffold<HasuraData>(
   (props) => (

--- a/scaffolds/hasura/scaffold.tsx
+++ b/scaffolds/hasura/scaffold.tsx
@@ -3,7 +3,7 @@ import { Template, Zombi } from 'compiled/zombi';
 import { createScaffold } from 'cli/utils/scaffold-helpers';
 import { mergePrompts } from 'cli/utils/merge-prompts';
 import { NpmClientPrompt, PublishableApiKeyPrompt, SecretApiKeyPrompt } from 'scaffolds/prompts';
-import crypto = require('crypto');
+import crypto from 'crypto';
 
 type HasuraData = NpmClientPrompt.Data &
   PublishableApiKeyPrompt.Data &

--- a/scaffolds/hasura/scaffold.tsx
+++ b/scaffolds/hasura/scaffold.tsx
@@ -3,6 +3,7 @@ import { Template, Zombi } from 'compiled/zombi';
 import { createScaffold } from 'cli/utils/scaffold-helpers';
 import { mergePrompts } from 'cli/utils/merge-prompts';
 import { NpmClientPrompt, PublishableApiKeyPrompt, SecretApiKeyPrompt } from 'scaffolds/prompts';
+import crypto = require('crypto');
 
 type HasuraData = NpmClientPrompt.Data &
   PublishableApiKeyPrompt.Data &
@@ -11,10 +12,16 @@ type HasuraData = NpmClientPrompt.Data &
     jwtSecret: string;
   };
 
+const generateJwtSecret = () => {
+  const buffer = crypto.randomBytes(32);
+  return buffer.toString('hex');
+};
+
 export default createScaffold<HasuraData>(
   (props) => (
     <Zombi
       {...props}
+      data={{ ...props.data, jwtSecret: props.data.jwtSecret ?? generateJwtSecret() }}
       prompts={mergePrompts(
         PublishableApiKeyPrompt.questions,
         SecretApiKeyPrompt.questions,
@@ -23,12 +30,6 @@ export default createScaffold<HasuraData>(
           type: 'input',
           name: 'hasuraUrl',
           message: "Enter your project's Hasura URL:",
-        },
-
-        {
-          type: 'input',
-          name: 'jwtSecret',
-          message: 'Enter your 32+ character JWT secret:',
         },
 
         NpmClientPrompt.questions,


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

Removes a prompt from the Hasura template and makes it so users can skip having to generate a JWT secret themselves

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
