### PR TITLE
Detect invalid Social Login provider input in the interactive flow

### DIFF
--- a/scaffolds/prompts.ts
+++ b/scaffolds/prompts.ts
@@ -96,6 +96,15 @@ export namespace SocialLoginsPrompt {
     name: 'socialLogin',
     message: 'Choose your social login providers:',
     choices: providers,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore: This is a bug in the typing from `zombi`. `validate` should be an acceptable field...
+    validate: (value: SocialLoginProvider[]) => {
+      if (!value.length) {
+        return `Please select at least one social login provider.`;
+      }
+
+      return true;
+    },
   };
 
   export const flags: Flags<Data> = {
@@ -104,7 +113,7 @@ export namespace SocialLoginsPrompt {
       description: `The social login provider(s) of your choice. You can provide this flag multiple times to select multiple providers. (one of: ${providers.join(
         ', ',
       )})`,
-      validate: (value) => {
+      validate: (value: SocialLoginProvider[]) => {
         const invalid: string[] = [];
 
         value.forEach((i) => {


### PR DESCRIPTION
### 📦 Pull Request

If no social login providers were selected using the interactive flow of `hello-world-social-login`, then an error would be raised at runtime suggesting a broken import path.

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
