### PR TITLE
Update templates to include `auth.magic.link/sdk` CDN references

### DIFF
--- a/scaffolds/binance-smart-chain/template/index.html
+++ b/scaffolds/binance-smart-chain/template/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
-    <script src="https://cdn.jsdelivr.net/npm/magic-sdk/dist/magic.js"></script>
+    <script src="https://auth.magic.link/sdk"></script>
     <script src="https://cdn.jsdelivr.net/npm/web3@1.3.4/dist/web3.min.js"></script>
     <script>
       const BSCOptions = {

--- a/scaffolds/hello-world-quickstart/template/index.html
+++ b/scaffolds/hello-world-quickstart/template/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" type="text/css" href="styles.css" />
   <!-- 1️⃣ Install Magic SDK -->
-  <script src="https://cdn.jsdelivr.net/npm/magic-sdk@latest/dist/magic.js"></script>
+  <script src="https://auth.magic.link/sdk"></script>
   <script>
     /* 2️⃣ Initialize Magic Instance */
     let magic = new Magic("<%= publishableApiKey %>");

--- a/scaffolds/hello-world/template/index.html
+++ b/scaffolds/hello-world/template/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" type="text/css" href="styles.css" />
     <!-- 1️⃣ Install Magic SDK -->
-    <script src="https://cdn.jsdelivr.net/npm/magic-sdk@latest/dist/magic.js"></script>
+    <script src="https://auth.magic.link/sdk"></script>
     <script>
       /* 2️⃣ Initialize Magic Instance */
       let magic = new Magic("<%= publishableApiKey %>");


### PR DESCRIPTION
### 📦 Pull Request

Instead of pointing at JSDelivr as the Magic SDK CDN, we are pointing at `https://auth.magic.link/sdk` instead.
