### PR TITLE
Sveltekit context updated to stuff

### DIFF
--- a/scaffolds/svelte/template/src/routes/__layout.svelte
+++ b/scaffolds/svelte/template/src/routes/__layout.svelte
@@ -10,7 +10,7 @@
 		});
 		return {
 			status: 200,
-			context: {
+			stuff: {
 				user
 			}
 		};


### PR DESCRIPTION
Context was updated to stuff 
> Error: You are returning "context" from a load function. "context" was renamed to "stuff", please adjust your code accordingly.

### 📦 Pull Request
So I was trying out make magic cli and scaffolded the sveltekit project
but i got the error in browser ; 

### ✅ Fixed Issues

-Fixes #68 
### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
