### PR TITLE
removes @magic-ext/auth

### DIFF
--- a/scaffolds/nextjs-dedicated-wallet/template/package.json
+++ b/scaffolds/nextjs-dedicated-wallet/template/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint --fix"
   },
   "dependencies": {
-    "@magic-ext/auth": "^4.0.0",
     "@magic-ext/oauth": "^15.0.0",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",

--- a/scaffolds/nextjs-dedicated-wallet/template/src/components/magic/MagicProvider.tsx
+++ b/scaffolds/nextjs-dedicated-wallet/template/src/components/magic/MagicProvider.tsx
@@ -1,11 +1,10 @@
 import { getChainId, getNetworkUrl } from '@/utils/network';
 import { OAuthExtension } from '@magic-ext/oauth';
-import { AuthExtension } from '@magic-ext/auth';
 import { Magic as MagicBase } from 'magic-sdk';
 import { ReactNode, createContext, useContext, useEffect, useMemo, useState } from 'react';
 const { Web3 } = require('web3');
 
-export type Magic = MagicBase<AuthExtension & OAuthExtension[]>;
+export type Magic = MagicBase<OAuthExtension[]>;
 
 type MagicContextType = {
   magic: Magic | null;
@@ -30,7 +29,7 @@ const MagicProvider = ({ children }: { children: ReactNode }) => {
           rpcUrl: getNetworkUrl(),
           chainId: getChainId(),
         },
-        extensions: [new AuthExtension(), new OAuthExtension()],
+        extensions: [new OAuthExtension()],
       });
 
       setMagic(magic);

--- a/scaffolds/nextjs-flow-dedicated-wallet/template/package-lock.json
+++ b/scaffolds/nextjs-flow-dedicated-wallet/template/package-lock.json
@@ -8,7 +8,6 @@
 			"name": "nextjs-magic-auth-template",
 			"version": "0.1.0",
 			"dependencies": {
-				"@magic-ext/auth": "^1.4.1",
 				"@magic-ext/flow": "^14.3.1",
 				"@magic-ext/oauth": "^12.4.1",
 				"@onflow/fcl": "^1.6.0",

--- a/scaffolds/nextjs-flow-dedicated-wallet/template/package.json
+++ b/scaffolds/nextjs-flow-dedicated-wallet/template/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint --fix"
   },
   "dependencies": {
-    "@magic-ext/auth": "^4.0.0",
     "@magic-ext/flow": "^16.0.0",
     "@magic-ext/oauth": "^15.0.0",
     "@onflow/fcl": "^1.6.0",

--- a/scaffolds/nextjs-flow-dedicated-wallet/template/src/components/magic/MagicProvider.tsx
+++ b/scaffolds/nextjs-flow-dedicated-wallet/template/src/components/magic/MagicProvider.tsx
@@ -1,6 +1,5 @@
 import {getNetwork, getNetworkUrl} from '@/utils/network'
 import {OAuthExtension} from '@magic-ext/oauth'
-import {AuthExtension} from '@magic-ext/auth'
 import {Magic as MagicBase} from 'magic-sdk'
 import {
 	ReactNode,
@@ -14,7 +13,7 @@ import {FlowExtension} from '@magic-ext/flow'
 import * as fcl from '@onflow/fcl'
 
 export type Magic = MagicBase<
-	AuthExtension & OAuthExtension[] & FlowExtension[]
+	OAuthExtension[] & FlowExtension[]
 >
 
 type MagicContextType = {
@@ -36,7 +35,6 @@ const MagicProvider = ({children}: {children: ReactNode}) => {
 				process.env.NEXT_PUBLIC_MAGIC_API_KEY as string,
 				{
 					extensions: [
-						new AuthExtension(),
 						new OAuthExtension(),
 						new FlowExtension({
 							rpcUrl: getNetworkUrl(),

--- a/scaffolds/nextjs-solana-dedicated-wallet/template/package.json
+++ b/scaffolds/nextjs-solana-dedicated-wallet/template/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint --fix"
   },
   "dependencies": {
-    "@magic-ext/auth": "^4.0.0",
     "@magic-ext/oauth": "^15.0.0",
     "@magic-ext/solana": "^17.0.0",
     "@solana/web3.js": "^1.87.1",

--- a/scaffolds/nextjs-solana-dedicated-wallet/template/src/components/magic/MagicProvider.tsx
+++ b/scaffolds/nextjs-solana-dedicated-wallet/template/src/components/magic/MagicProvider.tsx
@@ -1,6 +1,5 @@
 import {getNetworkUrl} from '@/utils/network'
 import {OAuthExtension} from '@magic-ext/oauth'
-import {AuthExtension} from '@magic-ext/auth'
 import {Magic as MagicBase} from 'magic-sdk'
 import {
 	ReactNode,
@@ -14,7 +13,7 @@ import {SolanaExtension} from '@magic-ext/solana'
 import {Connection} from '@solana/web3.js'
 
 export type Magic = MagicBase<
-	AuthExtension & OAuthExtension[] & SolanaExtension[]
+	OAuthExtension[] & SolanaExtension[]
 >
 
 type MagicContextType = {
@@ -39,7 +38,6 @@ const MagicProvider = ({children}: {children: ReactNode}) => {
 				process.env.NEXT_PUBLIC_MAGIC_API_KEY as string,
 				{
 					extensions: [
-						new AuthExtension(),
 						new OAuthExtension(),
 						new SolanaExtension({
 							rpcUrl: getNetworkUrl(),


### PR DESCRIPTION
### 📦 Pull Request

[Provide a general summary of the pull request here.]

### ✅ Fixed Issues

- Removes deprecated package; [@magic-ext/auth](https://www.npmjs.com/package/@magic-ext/auth?activeTab=versions)
- [Custom email template feature](https://magic.link/docs/custom-email-template) was not working because the auth extension was configured to the Magic object in the NextJS Dedicated app.

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
